### PR TITLE
Add script for restart dev server

### DIFF
--- a/script/dev_server_restarter.js
+++ b/script/dev_server_restarter.js
@@ -1,0 +1,46 @@
+const { spawnSync, spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const env = {
+	PHASE: "local",
+	REDIS_ADDRS: "localhost:6379",
+};
+
+function throttle(fn, duration) {
+	return (function () {
+		let timeout;
+		return function (...args) {
+			if (!timeout) {
+				fn(...args);
+				timeout = setTimeout(() => {
+					timeout = null;
+				}, duration);
+			}
+		};
+	})();
+}
+
+function runServer() {
+	spawnSync("go build", { stdio: "inherit", env: { ...process.env, ...env } });
+	return spawn("./hit-counter", ["-tls=0", "-addr=:8080"], {
+		stdio: "inherit",
+		env: { ...process.env, ...env },
+	});
+}
+
+function main() {
+	let devServer;
+	devServer = runServer();
+	fs.watch(
+		path.join(__dirname, "../view"),
+		throttle(() => {
+			if (devServer) {
+				devServer.kill();
+			}
+			devServer = runServer();
+		}, 1000)
+	);
+}
+
+main();


### PR DESCRIPTION
Added new script for the convenience of development.
The Script restart the development server when it detects changes in view files.

We don't have to `build` and `execute hit-counter` whenever changes occur.

**How to run the script**
```
$ node script/dev_server_restarter
```