### PR TITLE
Make graph style responsible to screen size

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -169,6 +169,15 @@
 
 /* Badge End */
 
+/* History Start */
+
+.graph_img{
+  width: 100%;
+  max-width: 800px;
+}
+
+/* History End */
+
 /* Notice Start */
 .notice{
   position: fixed;

--- a/script/dev_server_restarter.js
+++ b/script/dev_server_restarter.js
@@ -22,7 +22,7 @@ function throttle(fn, duration) {
 }
 
 function runServer() {
-	spawnSync(path.join(__dirname, "make_wasm \"local\""))
+	spawnSync("bash", [path.join(__dirname, "./build.sh"), "make_wasm", "local"]);
 	spawnSync("go build", { stdio: "inherit", env: { ...process.env, ...env } });
 	return spawn(path.join(__dirname, "..","hit-counter"), ["-tls=0", "-addr=:8080"], {
 		stdio: "inherit",

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -112,11 +113,12 @@ func showGraph(value string) {
 			}
 			defer res.Body.Close()
 			body, err := ioutil.ReadAll(res.Body)
+			encodedBody := base64.StdEncoding.EncodeToString(body)
 			if err != nil {
 				js.Global().Get("document").Call("getElementById", "history_view").Set("innerHTML", "Error")
 				return
 			}
-			js.Global().Get("document").Call("getElementById", "history_view").Set("innerHTML", string(body))
+			js.Global().Get("document").Call("getElementById", "history_view").Set("innerHTML", "<img src=\"data:image/svg+xml;base64,"+encodedBody+"\"></div>")
 		}(value)
 	}
 }


### PR DESCRIPTION
I changed `svg` tag to `img` tag to make graph style responsible to screen size.

`wasm` file has been changed in order to put encoded svg data to img tag.